### PR TITLE
feat: 회원이 접근가능한 API에 요청 보낼 때 쓸 AxiosInstance 구현

### DIFF
--- a/src/routes/components/NavSideBar.js
+++ b/src/routes/components/NavSideBar.js
@@ -1,9 +1,7 @@
 import { Offcanvas } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
-import { setNavShow } from '../../store/nav.slice';
-import './NavSideBar.css';
-import { setUser } from '../../store/user.slice';
+import userApiAxios from "../../utils/user-api-axios";
 
 const NavSideBar = () => {
   const handleClose = () => dispatch(setNavShow(false));
@@ -39,13 +37,19 @@ const NavSideBar = () => {
   )
 
   function signout() {
-    // TODO: 백엔드 서버에 signout API를 통해 캐시(or Redis)에 저장된
-    // refreshToken 지우는 작업 필요. 
-    // 위 요청 성공 시 아래 함수들 실행하게 변경 필요.
-    alert("로그아웃 완료");
-    deleteCookie('accessToken');
-    deleteCookie('refreshToken');
-    dispatch(setUser({}));
+    userApiAxios
+      .post("/auth/signout", { withCredentials: true })
+      .then((response) => {
+        alert("로그아웃 완료");
+        deleteCookie("accessToken");
+        deleteCookie("refreshToken");
+        dispatch(setUser({}));
+      })
+      .catch((err) => {
+        alert("로그인된 상태가 아닙니다.");
+        dispatch(setUser({}));
+      });
+
     // TODO: 로그아웃 시 비회원이 볼 수 없는 페이지에 있는 상황에 대한 조치 필요
   };
   

--- a/src/routes/components/NavSideBar.js
+++ b/src/routes/components/NavSideBar.js
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { setNavShow } from '../../store/nav.slice';
 import './NavSideBar.css';
 import { setUser } from '../../store/user.slice';
-import userApiAxios from "../../utils/user-api-axios";
+import apiAxios from "../../utils/api-axios";
 
 const NavSideBar = () => {
   const handleClose = () => dispatch(setNavShow(false));
@@ -40,7 +40,7 @@ const NavSideBar = () => {
   )
 
   function signout() {
-    userApiAxios
+    apiAxios
       .post("/api/auth/signout", { withCredentials: true })
       .then((response) => {
         alert("로그아웃 완료");

--- a/src/routes/components/NavSideBar.js
+++ b/src/routes/components/NavSideBar.js
@@ -41,7 +41,7 @@ const NavSideBar = () => {
 
   function signout() {
     userApiAxios
-      .post("/auth/signout", { withCredentials: true })
+      .post("/api/auth/signout", { withCredentials: true })
       .then((response) => {
         alert("로그아웃 완료");
         deleteCookie("accessToken");

--- a/src/routes/components/NavSideBar.js
+++ b/src/routes/components/NavSideBar.js
@@ -1,6 +1,9 @@
 import { Offcanvas } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
+import { setNavShow } from '../../store/nav.slice';
+import './NavSideBar.css';
+import { setUser } from '../../store/user.slice';
 import userApiAxios from "../../utils/user-api-axios";
 
 const NavSideBar = () => {

--- a/src/utils/api-axios.js
+++ b/src/utils/api-axios.js
@@ -1,11 +1,11 @@
 import axios from "axios";
 
-const userApiAxios = axios.create({
+const apiAxios = axios.create({
   baseURL: "http://localhost:8080",
   withCredentials: true,
 });
 
-userApiAxios.interceptors.response.use(
+apiAxios.interceptors.response.use(
   (res) => res,
   async (err) => {
     const { config } = err;
@@ -24,11 +24,11 @@ userApiAxios.interceptors.response.use(
 
     if (isAdminApi) {
       // TODO: 만약 Admin API가 백엔드에서 쿠키를 지정해주는 방식이 아니라 클라이언트에서 하기로 하면 바꾸어야함
-      await userApiAxios.get(refreshUrl);
+      await apiAxios.get(refreshUrl);
     } else {
       const {
         data: { accessToken },
-      } = await userApiAxios.get(refreshUrl);
+      } = await apiAxios.get(refreshUrl);
 
       if (!accessToken) {
         return Promise.reject(err);
@@ -41,4 +41,4 @@ userApiAxios.interceptors.response.use(
   }
 );
 
-export default userApiAxios;
+export default apiAxios;

--- a/src/utils/user-api-axios.js
+++ b/src/utils/user-api-axios.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const userApiAxios = axios.create({
-  baseURL: "http://localhost:8080/api",
+  baseURL: "http://localhost:8080",
   withCredentials: true
 });
 

--- a/src/utils/user-api-axios.js
+++ b/src/utils/user-api-axios.js
@@ -2,6 +2,7 @@ import axios from "axios";
 
 const userApiAxios = axios.create({
   baseURL: "http://localhost:8080/api",
+  withCredentials: true
 });
 
 userApiAxios.interceptors.response.use(
@@ -22,9 +23,7 @@ userApiAxios.interceptors.response.use(
 
     const {
       data: { accessToken },
-    } = await userApiAxios.get("/auth/refresh", {
-      withCredentials: true,
-    });
+    } = await userApiAxios.get("/auth/refresh");
 
     if (!accessToken) {
       return Promise.reject(err);

--- a/src/utils/user-api-axios.js
+++ b/src/utils/user-api-axios.js
@@ -1,0 +1,39 @@
+import axios from "axios";
+
+const userApiAxios = axios.create({
+  baseURL: "http://localhost:8080/api",
+});
+
+userApiAxios.interceptors.response.use(
+  (res) => res,
+  async (err) => {
+    const { config } = err;
+
+    if (
+      config.url.startsWith("/admin") ||
+      config.url === "/auth/refresh" ||
+      err.response.status !== 401 ||
+      config.sent
+    ) {
+      return Promise.reject(err);
+    }
+
+    config.sent = true;
+
+    const {
+      data: { accessToken },
+    } = await userApiAxios.get("/auth/refresh", {
+      withCredentials: true,
+    });
+
+    if (!accessToken) {
+      return Promise.reject(err);
+    }
+
+    document.cookie = `accessToken=${accessToken}; path=/;`;
+
+    return axios(config);
+  }
+);
+
+export default userApiAxios;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가   
- [ ] 기능 수정   
- [ ] 기능 삭제   
- [ ] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- resolve #6
- 기존에 사용하던 axios를 대체하여 사용할 수 있는 userApiAxios 객체를 export.
- userApiAxios는 기본 설정으로 api url prefix를 'http://localhost:8080/api'로 설정하여, 주소는 /auth/signin 처럼 간략하게 쓸 수 있음.
- withCredentials을 true로 설정하고 있어서, userApiAxios를 사용하면 한 번 더 쓰지 않아도 됨.

### 선행 필요
- 백엔드 PR 중 액세스 토큰 재발급을 위한 API (GET /api/auth/refresh) PR이 통과되어야합니다.

### 참고사항
- 관리자는 따로 토큰들이 있으므로 관리자 API는 전용 AxiosInstance를 따로 만들어야함.
- /auth/signin처럼 간략하게 쓸수도 있지만 full url 써도 에러는 안 남.

### 리뷰 요청
- 폴더와 파일 위치, 파일 이름, 내보내는 이름 등등 네이밍이나 폴더구조 등으로 수정해야한다면 알려주세요.