### PR TITLE
feat: 소셜 로그인을 새창 띄워서 하도록 변경

### DIFF
--- a/src/environments/common.js
+++ b/src/environments/common.js
@@ -1,0 +1,3 @@
+export default {
+  origin: 'http://localhost:3000'
+}

--- a/src/routes/auth/AuthSigninModal.js
+++ b/src/routes/auth/AuthSigninModal.js
@@ -39,10 +39,10 @@ function AuthSigninModal() {
       <div className="d-grid gap-2 m-2">
         <Button variant="primary" onClick={() => {login()}}>로그인</Button>
         <Button variant="outline-dark" onClick={()=>{handleClose();showModal('signup');}}>아직 회원가입을 안하셨다면?</Button>
-        <a href={naverLoginUri} target="_self">
+        <a onClick={() => socialLogin(naverLoginUri)}>
           <img src={NaverLoginImage} />
         </a>
-        <a href={kakaoLoginUri} target="_self">
+        <a onClick={() => socialLogin(kakaoLoginUri)}>
           <img src={KakaoLoginImage} />
         </a>
       </div>
@@ -78,6 +78,32 @@ function AuthSigninModal() {
         console.log("axios 통신실패");
         alert(e.response.data.message);
       });
+  }
+
+  function socialLogin(url) {
+    window.addEventListener("message", SocialLoginListenerFn)
+    window.open(url, 'social')
+  }
+
+  function SocialLoginListenerFn(e) {
+    handleSocialLoginMessage(e.data)
+  }
+
+  function handleSocialLoginMessage({ accessToken, refreshToken, err }) {
+    if (err) {
+      alert('로그인 실패')
+      return ;
+    }
+    dispatch(setShow(false));
+    alert('로그인 성공')
+
+    document.cookie = `accessToken=${accessToken}; path=/;`;
+    document.cookie = `refreshToken=${refreshToken}; path=/;`;
+
+    const userInfo = jwt_decode(accessToken);
+    dispatch(setUser(userInfo));
+    dispatch(setLogin(true));
+    window.removeEventListener("message", SocialLoginListenerFn)
   }
 }
 

--- a/src/routes/auth/AuthSigninModal.js
+++ b/src/routes/auth/AuthSigninModal.js
@@ -39,12 +39,12 @@ function AuthSigninModal() {
       <div className="d-grid gap-2 m-2">
         <Button variant="primary" onClick={() => {login()}}>로그인</Button>
         <Button variant="outline-dark" onClick={()=>{handleClose();showModal('signup');}}>아직 회원가입을 안하셨다면?</Button>
-        <a onClick={() => socialLogin(naverLoginUri)}>
-          <img src={NaverLoginImage} />
-        </a>
-        <a onClick={() => socialLogin(kakaoLoginUri)}>
-          <img src={KakaoLoginImage} />
-        </a>
+        <div onClick={() => socialLogin(naverLoginUri)} style={{cursor: 'pointer'}}>
+          <img src={NaverLoginImage} alt="네이버 로그인 버튼" />
+        </div>
+        <div onClick={() => socialLogin(kakaoLoginUri)} style={{cursor: 'pointer'}}>
+          <img src={KakaoLoginImage} alt="카카오 로그인 버튼" />
+        </div>
       </div>
     </Modal>
   );

--- a/src/routes/auth/AuthSigninModal.js
+++ b/src/routes/auth/AuthSigninModal.js
@@ -91,11 +91,9 @@ function AuthSigninModal() {
 
   function handleSocialLoginMessage({ accessToken, refreshToken, err }) {
     if (err) {
-      alert('로그인 실패')
       return ;
     }
     dispatch(setShow(false));
-    alert('로그인 성공')
 
     document.cookie = `accessToken=${accessToken}; path=/;`;
     document.cookie = `refreshToken=${refreshToken}; path=/;`;

--- a/src/routes/auth/AuthSigninModal.js
+++ b/src/routes/auth/AuthSigninModal.js
@@ -79,17 +79,8 @@ function AuthSigninModal() {
         alert(e.response.data.message);
       });
   }
-
-  function socialLogin(url) {
-    window.addEventListener("message", SocialLoginListenerFn)
-    window.open(url, 'social')
-  }
-
-  function SocialLoginListenerFn(e) {
-    handleSocialLoginMessage(e.data)
-  }
-
-  function handleSocialLoginMessage({ accessToken, refreshToken, err }) {
+  
+  function afterSocialLogin({ accessToken, refreshToken, err }) {
     if (err) {
       return ;
     }
@@ -101,8 +92,13 @@ function AuthSigninModal() {
     const userInfo = jwt_decode(accessToken);
     dispatch(setUser(userInfo));
     dispatch(setLogin(true));
-    window.removeEventListener("message", SocialLoginListenerFn)
   }
+
+  function socialLogin(url) {
+    window.afterSocialLogin = afterSocialLogin
+    window.open(url, 'social', 'width=700px,height=800px,scrollbars=no')
+  }
+
 }
 
 export default AuthSigninModal;

--- a/src/routes/auth/AuthSigninModal.js
+++ b/src/routes/auth/AuthSigninModal.js
@@ -96,7 +96,7 @@ function AuthSigninModal() {
 
   function socialLogin(url) {
     window.afterSocialLogin = afterSocialLogin
-    window.open(url, 'social', 'width=700px,height=800px,scrollbars=no')
+    window.open(url, 'social', 'width=600,height=600')
   }
 
 }

--- a/src/routes/oauth/KakaoLoginRedirect.js
+++ b/src/routes/oauth/KakaoLoginRedirect.js
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import apiAxios from "../../utils/api-axios";
+import Loading from '../components/loading/Loading'
 
 const KaKaoLoginRedirect = () => {
 
@@ -17,17 +18,22 @@ const KaKaoLoginRedirect = () => {
         .then((response) => {
           const accessToken = response.data.accessToken;
           const refreshToken = response.data.refreshToken;
-          window.close()
           window.opener?.afterSocialLogin({accessToken, refreshToken})
         })
         .catch((err) => {
-          window.close()
           window.opener?.afterSocialLogin({err})
+        })
+        .finally(() => {
+          window.close()
         })
     }
   }, []);
 
-  return <div>카카오 소셜 로그인 리다이렉트 페이지</div>;
+  return (
+    <div>
+      <Loading />
+    </div>
+  );
 };
 
 export default KaKaoLoginRedirect;

--- a/src/routes/oauth/KakaoLoginRedirect.js
+++ b/src/routes/oauth/KakaoLoginRedirect.js
@@ -1,14 +1,7 @@
-import jwt_decode from "jwt-decode";
 import { useEffect } from "react";
-import { useDispatch } from "react-redux";
-import { useNavigate } from 'react-router-dom';
-import { setShow } from "../../store/modal.slice";
-import { setLogin, setUser } from '../../store/user.slice';
 import apiAxios from "../../utils/api-axios";
 
 const KaKaoLoginRedirect = () => {
-  let navigate = useNavigate();
-  let dispatch = useDispatch();
 
   useEffect(() => {
     const temp = {};

--- a/src/routes/oauth/KakaoLoginRedirect.js
+++ b/src/routes/oauth/KakaoLoginRedirect.js
@@ -17,15 +17,12 @@ const KaKaoLoginRedirect = () => {
         .then((response) => {
           const accessToken = response.data.accessToken;
           const refreshToken = response.data.refreshToken;
-          if (window.opener) {
-            window.opener.postMessage({accessToken, refreshToken}, '*')
-          }
+          window.close()
+          window.opener?.afterSocialLogin({accessToken, refreshToken})
         })
         .catch((err) => {
-          window.opener?.postMessage({err}, '*')
-        })
-        .finally(() => {
           window.close()
+          window.opener?.afterSocialLogin({err})
         })
     }
   }, []);

--- a/src/routes/oauth/KakaoLoginRedirect.js
+++ b/src/routes/oauth/KakaoLoginRedirect.js
@@ -22,22 +22,18 @@ const KaKaoLoginRedirect = () => {
           code: temp.code,
         })
         .then((response) => {
-          alert("로그인 성공");
           const accessToken = response.data.accessToken;
           const refreshToken = response.data.refreshToken;
-          document.cookie = `accessToken=${accessToken}; path=/;`;
-          document.cookie = `refreshToken=${refreshToken}; path=/;`;
-
-          const userInfo = jwt_decode(accessToken);
-          dispatch(setUser(userInfo));
-          dispatch(setLogin(true));
-          dispatch(setShow(false));
-          navigate('/')
+          if (window.opener) {
+            window.opener.postMessage({accessToken, refreshToken}, '*')
+          }
         })
         .catch((err) => {
-          console.log(err);
-          alert("로그인 실패");
-        });
+          window.opener?.postMessage({err}, '*')
+        })
+        .finally(() => {
+          window.close()
+        })
     }
   }, []);
 

--- a/src/routes/oauth/NaverLoginRedirect.js
+++ b/src/routes/oauth/NaverLoginRedirect.js
@@ -1,14 +1,7 @@
-import jwt_decode from "jwt-decode";
 import { useEffect } from "react";
-import { useDispatch } from "react-redux";
-import { useNavigate } from 'react-router-dom';
-import { setShow } from "../../store/modal.slice";
-import { setLogin, setUser } from '../../store/user.slice';
 import apiAxios from "../../utils/api-axios";
 
 const NaverLoginRedirect = () => {
-  let navigate = useNavigate();
-  let dispatch = useDispatch();
 
   useEffect(() => {
     const temp = {};

--- a/src/routes/oauth/NaverLoginRedirect.js
+++ b/src/routes/oauth/NaverLoginRedirect.js
@@ -23,22 +23,16 @@ const NaverLoginRedirect = () => {
           state: temp.state,
         })
         .then((response) => {
-          alert("로그인 성공");
           const accessToken = response.data.accessToken;
           const refreshToken = response.data.refreshToken;
-          document.cookie = `accessToken=${accessToken}; path=/;`;
-          document.cookie = `refreshToken=${refreshToken}; path=/;`;
-
-          const userInfo = jwt_decode(accessToken);
-          dispatch(setUser(userInfo));
-          dispatch(setLogin(true));
-          dispatch(setShow(false));
-          navigate('/')
+          window.opener?.postMessage({accessToken, refreshToken}, '*')
         })
         .catch((err) => {
-          console.log(err);
-          alert("로그인 실패");
-        });
+          window.opener?.postMessage({err}, '*')
+        })
+        .finally(() => {
+          window.close()
+        })
     }
   }, []);
 

--- a/src/routes/oauth/NaverLoginRedirect.js
+++ b/src/routes/oauth/NaverLoginRedirect.js
@@ -18,13 +18,12 @@ const NaverLoginRedirect = () => {
         .then((response) => {
           const accessToken = response.data.accessToken;
           const refreshToken = response.data.refreshToken;
-          window.opener?.postMessage({accessToken, refreshToken}, '*')
+          window.close()
+          window.opener?.afterSocialLogin({accessToken, refreshToken})
         })
         .catch((err) => {
-          window.opener?.postMessage({err}, '*')
-        })
-        .finally(() => {
           window.close()
+          window.opener?.afterSocialLogin({err})
         })
     }
   }, []);

--- a/src/routes/oauth/NaverLoginRedirect.js
+++ b/src/routes/oauth/NaverLoginRedirect.js
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import apiAxios from "../../utils/api-axios";
+import Loading from '../components/loading/Loading'
 
 const NaverLoginRedirect = () => {
 
@@ -18,19 +19,20 @@ const NaverLoginRedirect = () => {
         .then((response) => {
           const accessToken = response.data.accessToken;
           const refreshToken = response.data.refreshToken;
-          window.close()
           window.opener?.afterSocialLogin({accessToken, refreshToken})
         })
         .catch((err) => {
-          window.close()
           window.opener?.afterSocialLogin({err})
+        })
+        .finally(() => {
+          window.close()
         })
     }
   }, []);
 
   return (
     <div>
-      네이버 소셜 로그인 리다이렉트 페이지
+      <Loading />
     </div>
   )
 };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [ ] 기능 추가   
- [x] 기능 수정   
- [ ] 기능 삭제   
- [ ] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

### 변경 사항
- resolve #28
  - 소셜 로그인의 방식 변경
  - (전 방식) 현 페이지가 이동하여 리다이렉트 url로 간 다음, 다시 메인으로 돌아옴
  - (현 방식) 팝업을 띄워서 거기서 로그인처리를 한 다음, 원래 페이지로 액세스 토큰, 리프레시 토큰을 돌려줘서 원래 페이지에서 처리 