### PR TITLE
fix: meetups 나의 모임 클릭 상태에서 검색 시 해제되게 변경

### DIFF
--- a/src/routes/meetups/MeetupsList.js
+++ b/src/routes/meetups/MeetupsList.js
@@ -113,6 +113,7 @@ const MeetupsList = () => {
   }
 
   async function goSearch() {
+    setCheckedMine(false);
     keyword.current = inputKeyword;
     page.current = 2;
     document.querySelector('#scrollEnd').hidden = false;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [ ] 기능 추가   
- [ ] 기능 수정   
- [ ] 기능 삭제   
- [x] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

### 변경 사항
- 나의 모임 버튼 클릭된 상태에서 검색 시 그대로 클릭 상태로 남아있는 버그 있었는데   
검색하면 해제되게 해당 버그 수정
