### PR TITLE
feat: 포토스팟 관리 페이지 추가(콜렉션 관리에서 개별 콜렉션을 누르면 뜸.)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import AdminAccount from './routes/admin/AdminAccount';
 import AdminMeetup from './routes/admin/AdminMeetup';
 import UserPage from './pages/UserPage'
 import AdminMain from './routes/admin/AdminMain';
+import AdminPhotospot from './routes/admin/AdminPhotospot';
 
 function App() {
 
@@ -33,6 +34,7 @@ function App() {
         <Route path="/admin" element={<AdminPage MainComponent={AdminMain} />}></Route>
         <Route path="/admin/users" element={<AdminPage MainComponent={AdminUser} />}></Route>
         <Route path="/admin/collections" element={<AdminPage MainComponent={AdminCollection} />}></Route>
+        <Route path="/admin/collections/:collectionId/photospots" element={<AdminPage MainComponent={AdminPhotospot} />}></Route>
         <Route path="/admin/meetups" element={<AdminPage MainComponent={AdminMeetup} />}></Route>
         <Route path="/admin/faqs" element={<AdminPage MainComponent={AdminFAQ} />}></Route>
         <Route path="/admin/accounts" element={<AdminPage MainComponent={AdminAccount} />}></Route>

--- a/src/environments/admin.js
+++ b/src/environments/admin.js
@@ -32,6 +32,18 @@ const adminEnvironments = {
       (data) => data.createdAt, // 등록일자
     ],
   },
+  photospot: {
+    ko: '포토스팟', 
+    getItemPath: (collectionId) => `/admin/${collectionId}/photospots`,
+    header: ["ID", "포토스팟명", "한줄 소개", "등록일자", "삭제"],
+    width: [10, 20, 50, 10, 10],
+    transform: [
+      (data) => data.id, // ID
+      (data) => data.title, // 포토스팟명
+      (data) => data.description, // 한줄 소개
+      (data) => data.createdAt, // 등록일자
+    ],
+  },
   faq: {
     ko: '자주찾는질문', 
     getItemPath: '/admin/faq',

--- a/src/routes/admin/AdminPhotospot.js
+++ b/src/routes/admin/AdminPhotospot.js
@@ -1,16 +1,15 @@
 import { useEffect, useState } from "react";
-import { Button } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import adminEnvironments from "../../environments/admin";
-import { setModalName, setShow } from "../../store/modal.slice";
 import apiAxios from "../../utils/api-axios";
 import PaginationButtonList from "../components/PaginationButtonList";
 import AdminTable from "./AdminTable";
 import AdminCollectionDeleteButtons from "./components/AdminCollectionDeleteButton";
+import AdminPhotospotDeleteButtons from "./components/AdminPhotospotDeleteButton";
 import AdminSearch from "./components/AdminSearch";
 
-const AdminCollection = () => {
+const AdminPhotospot = () => {
   const {
     ko: koName,
     getItemPath,
@@ -18,7 +17,8 @@ const AdminCollection = () => {
     width,
     transform,
     itemPerPage,
-  } = adminEnvironments["collection"];
+  } = adminEnvironments["photospot"];
+  const { collectionId } = useParams()
 
   let [data, setData] = useState([]);
   let [original, setOriginal] = useState([]);
@@ -36,7 +36,7 @@ const AdminCollection = () => {
 
   return (
     <>
-      <h3>{koName} 관리</h3>
+      <h3>{koName} 관리 (콜렉션 ID: {collectionId})</h3>
       <AdminSearch
         onClick={goSearch}
         onChange={(e) => setkeyword(e.target.value)}
@@ -47,23 +47,15 @@ const AdminCollection = () => {
         data={data}
         original={original}
         done={done}
-        TableButtons={[AdminCollectionDeleteButtons]}
-        onClick={clickTable}
-      />
-      <PaginationButtonList
-        current={page}
-        total={total}
-        itemPerPage={itemPerPage}
-        changePage={setPage}
+        TableButtons={[AdminPhotospotDeleteButtons]}
       />
     </>
   );
 
   function goSearch() {
     apiAxios
-      .get(getItemPath, { params: { keyword, p: page } })
-      .then(({ status, data }) => {
-        const { data: items, total } = data;
+      .get(getItemPath(collectionId), { params: { keyword, p: page } })
+      .then(({ status, data: items }) => {
         const mappingData = items.map((item) =>
           transform.map((fn) => fn(item))
         );
@@ -88,12 +80,6 @@ const AdminCollection = () => {
       setOriginal(original.filter((value, index) => index !== order));
     }
   }
-  
-  function clickTable(entity) {
-    return function (e) {
-      navigate(`/admin/collections/${entity.id}/photospots`)
-    }
-  }
 };
 
-export default AdminCollection;
+export default AdminPhotospot;

--- a/src/routes/admin/AdminPhotospot.js
+++ b/src/routes/admin/AdminPhotospot.js
@@ -22,7 +22,7 @@ const AdminPhotospot = () => {
 
   let [data, setData] = useState([]);
   let [original, setOriginal] = useState([]);
-  let [keyword, setkeyword] = useState("");
+  let [search, setSearch] = useState("");
   let [page, setPage] = useState(1);
   let [total, setTotal] = useState(1);
 
@@ -39,7 +39,7 @@ const AdminPhotospot = () => {
       <h3>{koName} 관리 (콜렉션 ID: {collectionId})</h3>
       <AdminSearch
         onClick={goSearch}
-        onChange={(e) => setkeyword(e.target.value)}
+        onChange={(e) => setSearch(e.target.value)}
       />
       <AdminTable
         header={header}
@@ -54,7 +54,7 @@ const AdminPhotospot = () => {
 
   function goSearch() {
     apiAxios
-      .get(getItemPath(collectionId), { params: { keyword, p: page } })
+      .get(getItemPath(collectionId), { params: { search, p: page } })
       .then(({ status, data: items }) => {
         const mappingData = items.map((item) =>
           transform.map((fn) => fn(item))

--- a/src/routes/admin/AdminTable.js
+++ b/src/routes/admin/AdminTable.js
@@ -17,7 +17,7 @@ const AdminTable = ({ header, data, original, width, done, TableButtons, onClick
       </thead>
       <tbody>
         {data.map((slice, order) => (
-          <tr key={order} onClick={onClick ? onClick(original[order]) : () => {}}>
+          <tr key={order} onClick={onClick ? onClick(original[order]) : () => {}} style={ onClick ? {cursor: 'pointer'} : {}}>
             {slice.map((value, index) => (
               <td key={index}>{value}</td>
             ))}

--- a/src/routes/admin/components/AdminPhotospotDeleteButton.js
+++ b/src/routes/admin/components/AdminPhotospotDeleteButton.js
@@ -1,0 +1,34 @@
+import { Button } from "react-bootstrap";
+import { useNavigate } from "react-router-dom";
+import apiAxios from "../../../utils/api-axios";
+// import { showModal } from "../../../store/modal.slice";
+
+const AdminPhotospotDeleteButtons = ({ id, order, entity, done }) => {
+  const navigate = useNavigate();
+  return (
+    <>
+      <Button variant="primary" onClick={() => deletePhotospot(entity.collectionId, id)}>
+        삭제
+      </Button>
+    </>
+  );
+
+  function deletePhotospot(collectionId, id) {
+    apiAxios
+      .delete(`/admin/${collectionId}/photospots/${id}`)
+      .then(({ status, data }) => {
+        if (status === 200) {
+          alert("성공");
+          done();
+        }
+      })
+      .catch((err) => {
+         if (err.response.status === 401) {
+          navigate('/admin');
+        }
+        alert("실패");
+      });
+  }
+};
+
+export default AdminPhotospotDeleteButtons;

--- a/src/routes/components/AdminHeader.js
+++ b/src/routes/components/AdminHeader.js
@@ -41,7 +41,7 @@ const AdminHeader = () => {
           <div>
             <Button className="header-link" variant="link" active={location.pathname === '/admin/users'} onClick={() => navigate("/admin/users")}>유저 관리</Button>
             <Button className="header-link" variant="link" active={location.pathname === '/admin/meetups'} onClick={() => navigate("/admin/meetups")}>모임 관리</Button>
-            <Button className="header-link" variant="link" active={location.pathname === '/admin/collections'} onClick={() => navigate("/admin/collections")}>콜렉션 관리</Button>
+            <Button className="header-link" variant="link" active={location.pathname.startsWith('/admin/collections')} onClick={() => navigate("/admin/collections")}>콜렉션 관리</Button>
             <Button className="header-link" variant="link" active={location.pathname === '/admin/faqs'} onClick={() => navigate("/admin/faqs")}>자주찾는질문 관리</Button>
             <Button className="header-link" variant="link" active={location.pathname === '/admin/accounts'} onClick={() => navigate("/admin/accounts")}>관리자 계정관리</Button>
           </div>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가   
- [ ] 기능 수정   
- [ ] 기능 삭제   
- [ ] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

### 변경 사항
- resolve #34 
  - 포토스팟 관리 페이지 생성 (/admin/collections/:collectionId/photospots)
  - 콜렉션 관리 페이지에서 개별 콜렉션을 클릭하면 해당 콜렉션의 포토스팟 관리 페이지로 이동
  - 포토스팟 관리 페이지에서도 '콜렉션 관리' 링크 버튼이 흰색으로 띄워져있도록 ===를 startsWith 사용으로 변경.

### 추가사항
- 자유롭게 작성
