### PR TITLE
feat: 인증 중간발표 전 QA - 1차

### DIFF
--- a/src/routes/auth/AuthSigninModal.js
+++ b/src/routes/auth/AuthSigninModal.js
@@ -64,7 +64,7 @@ function AuthSigninModal() {
         const statusCode = response.status;
         // console.log('status code: ' + statusCode);
         if (statusCode === 200) {
-          alert("로그인 완료");
+          alert(response.data.message);
 
           const accessToken = response.data.accessToken;
 
@@ -76,7 +76,7 @@ function AuthSigninModal() {
       })
       .catch((e) => {
         console.log("axios 통신실패");
-        alert(e.response.data.message);
+        alert(e.response?.data.message);
       });
   }
 
@@ -92,6 +92,7 @@ function AuthSigninModal() {
       apiAxios
         .post(`/api/auth/oauth/signin/${provider}`, body)
         .then((response) => {
+          alert(response.data.message);
           const accessToken = response.data.accessToken;
           dispatch(setShow(false));
 
@@ -99,8 +100,8 @@ function AuthSigninModal() {
           dispatch(setUser(userInfo));
           dispatch(setLogin(true));
         })
-        .catch((err) => {
-          return;
+        .catch((e) => {
+          alert(e.response?.data.message);
         })
   }
 

--- a/src/routes/auth/AuthSignupModal.js
+++ b/src/routes/auth/AuthSignupModal.js
@@ -27,13 +27,15 @@ function AuthSignupModal() {
         <Form>
           <Form.Group className="mb-3">
             <InputGroup className="mb-2">
-              <Form.Control id="email" name="email" type="email" placeholder='이메일' autoFocus onChange={(e) => { setEmail(e.target.value); setIsVerified(false); }}/>
-              <Button variant="success" onClick={()=>{ sendEmail(); }}>인증번호 전송</Button>
+              <Form.Control disabled={isVerified} id="email" name="email" type="email" placeholder='이메일' autoFocus onChange={(e) => { setEmail(e.target.value); setIsVerified(false); }}/>
+              <Button disabled={isVerified} variant="success" onClick={()=>{ sendEmail(); }}>인증번호 전송</Button>
             </InputGroup>
+            {isSending ? <Form.Text>메일 보내는 중...</Form.Text> : ''}
             <InputGroup className="mb-2">
-              <Form.Control id="confirm_email" name="confirm_email" type="text" placeholder='인증번호' autoFocus onChange={(e) => { setVerifyToken(e.target.value); }}/>
-              <Button variant="outline-success" onClick={()=>{ confirmEmail(); }}>인증번호 확인</Button>
+              <Form.Control disabled={isVerified} id="confirm_email" name="confirm_email" type="text" placeholder='인증번호' autoFocus onChange={(e) => { setVerifyToken(e.target.value); }}/>
+              <Button disabled={isVerified} variant="outline-success" onClick={()=>{ confirmEmail(); }}>인증번호 확인</Button>
             </InputGroup>
+            {isVerified ? <Form.Text>메일 인증이 완료되었습니다.</Form.Text> : ''}
             <Form.Control id="nickname" className='mb-2' name="nickname" type="text" placeholder='닉네임' autoFocus onChange={(e) => { setUsername(e.target.value); }} />
             <Form.Control id="password" className='mb-2' name="password" type="password" placeholder='비밀번호' autoFocus onChange={(e) => { setPassword(e.target.value); }} />
             <Form.Control id="confirm_password" className='mb-2' name="confirm_password" type="password" placeholder='비밀번호확인' autoFocus onChange={(e) => { setConfirmPassword(e.target.value); }} />
@@ -41,7 +43,7 @@ function AuthSignupModal() {
         </Form>
       </Modal.Body>
       <div className="d-grid gap-2 m-2">
-        <Button variant="primary" onClick={()=>{ register(); }}>회원가입</Button>
+        <Button disabled={!isVerified || !username || !password || password !== confirmPassword} variant="primary" onClick={()=>{ register(); }}>회원가입</Button>
         <Button variant="outline-dark" onClick={()=>{handleClose();showModal('signin');}}>이미 가입하셨다면?</Button>
       </div>
     </Modal>
@@ -59,7 +61,7 @@ function AuthSignupModal() {
         const statusCode = response.status;
         // console.log('status code: ' + statusCode);
         if (statusCode === 200) {
-          alert('인증완료');
+          alert(response.data.message);
           setIsVerified(true);
         }
       })
@@ -81,11 +83,11 @@ function AuthSignupModal() {
         const statusCode = response.status;
         console.log('status code: ' + statusCode);
         if (statusCode === 201) {
+          setIsSending(false);
           alert(response.data.message);
         }
       })
       .catch((e) => {
-        setIsSending(false);
         console.log('axios 통신실패');
         alert(e.response?.data.message);
       });
@@ -105,7 +107,7 @@ function AuthSignupModal() {
       .then((response) => {
         const statusCode = response.status;
         console.log("status code: " + statusCode);
-        if (statusCode === 200) {
+        if (statusCode === 201) {
           alert(response.data.message);
           handleClose()
         }

--- a/src/routes/auth/AuthSignupModal.js
+++ b/src/routes/auth/AuthSignupModal.js
@@ -65,7 +65,7 @@ function AuthSignupModal() {
       })
       .catch((e) => {
         console.log('axios 통신실패');
-        alert(e.response.data.message);
+        alert(e.response?.data.message);
       });
   }
 
@@ -81,13 +81,13 @@ function AuthSignupModal() {
         const statusCode = response.status;
         console.log('status code: ' + statusCode);
         if (statusCode === 201) {
-          alert('인증번호를 이메일로 보냈습니다.');
+          alert(response.data.message);
         }
       })
       .catch((e) => {
         setIsSending(false);
         console.log('axios 통신실패');
-        alert(e.response.data.message);
+        alert(e.response?.data.message);
       });
   }
 
@@ -106,13 +106,13 @@ function AuthSignupModal() {
         const statusCode = response.status;
         console.log("status code: " + statusCode);
         if (statusCode === 200) {
-          alert("회원가입했습니다.");
+          alert(response.data.message);
           handleClose()
         }
       })
       .catch((e) => {
         console.log("axios 통신실패");
-        alert(e.response.data.message);
+        alert(e.response?.data.message);
       });
   }
 }

--- a/src/routes/auth/AuthSignupModal.js
+++ b/src/routes/auth/AuthSignupModal.js
@@ -5,6 +5,7 @@ import { useState } from "react";
 import apiAxios from '../../utils/api-axios';
 
 function AuthSignupModal() {
+  const [isSending, setIsSending] = useState(false);
   const [isVerified, setIsVerified] = useState(false);
   const [email, setEmail] = useState('');
   const [username, setUsername] = useState('');
@@ -53,7 +54,7 @@ function AuthSignupModal() {
 
   function confirmEmail() {
     apiAxios
-      .put(`/api/auth/emailverification`, { email, verifyToken })
+      .put(`/api/auth/emailverification/signup`, { email, verifyToken })
       .then((response) => {
         const statusCode = response.status;
         // console.log('status code: ' + statusCode);
@@ -73,8 +74,9 @@ function AuthSignupModal() {
       alert('이메일을 입력해야 합니다.');
       return;
     }
+    setIsSending(true);
     apiAxios
-      .post('/api/auth/emailverification', { email })
+      .post('/api/auth/emailverification/signup', { email })
       .then((response) => {
         const statusCode = response.status;
         console.log('status code: ' + statusCode);
@@ -83,8 +85,9 @@ function AuthSignupModal() {
         }
       })
       .catch((e) => {
+        setIsSending(false);
         console.log('axios 통신실패');
-        console.log(e);
+        alert(e.response.data.message);
       });
   }
 
@@ -102,14 +105,14 @@ function AuthSignupModal() {
       .then((response) => {
         const statusCode = response.status;
         console.log("status code: " + statusCode);
-        if (statusCode === 201) {
+        if (statusCode === 200) {
           alert("회원가입했습니다.");
           handleClose()
         }
       })
       .catch((e) => {
         console.log("axios 통신실패");
-        console.log(e);
+        alert(e.response.data.message);
       });
   }
 }

--- a/src/routes/auth/ChangePasswordModal.js
+++ b/src/routes/auth/ChangePasswordModal.js
@@ -25,20 +25,21 @@ function ChangePasswordModal() {
         <Form>
           <Form.Group className="mb-3">
             <div className="d-grid gap-2 m-2">
-              <Button variant="outline-success" onClick={()=>{ sendEmail(); }}>인증번호 발송</Button>
+              <Button disabled={isVerified} variant="outline-success" onClick={()=>{ sendEmail(); }}>인증번호 발송</Button>
             </div>
             {isSending ? <Form.Text>메일 보내는 중...</Form.Text> : ''}
             <InputGroup className="mb-2">
               <Form.Control id="p_confirm_email" name="confirm_email" type="text" placeholder='인증번호' autoFocus onChange={(e) => { setVerifyToken(e.target.value); }}/>
-              <Button variant="outline-success" onClick={()=>{ confirmEmail(); }}>인증번호 확인</Button>
+              <Button disabled={isVerified} variant="outline-success" onClick={()=>{ confirmEmail(); }}>인증번호 확인</Button>
             </InputGroup>
+            {isVerified ? <Form.Text>메일 인증이 완료되었습니다.</Form.Text> : ''}
             <Form.Control id="p_password" className='mb-2' name="password" type="password" placeholder='새 비밀번호' autoFocus onChange={(e) => { setPassword(e.target.value); }} />
             <Form.Control id="p_confirm_password" className='mb-2' name="confirm_password" type="password" placeholder='새 비밀번호확인' autoFocus onChange={(e) => { setConfirmPassword(e.target.value); }} />
           </Form.Group>
         </Form>
       </Modal.Body>
       <div className="d-grid gap-2 m-2">
-        <Button variant="primary" onClick={()=>{ changePassword(); }}>비밀번호 변경</Button>
+        <Button disabled={!isVerified || !password || password !== confirmPassword} variant="primary" onClick={()=>{ changePassword(); }}>비밀번호 변경</Button>
       </div>
     </Modal>
   )

--- a/src/routes/auth/ChangePasswordModal.js
+++ b/src/routes/auth/ChangePasswordModal.js
@@ -55,13 +55,13 @@ function ChangePasswordModal() {
         const statusCode = response.status;
         // console.log('status code: ' + statusCode);
         if (statusCode === 200) {
-          alert('인증완료');
+          alert(response.data.message);
           setIsVerified(true);
         }
       })
       .catch((e) => {
         console.log('axios 통신실패');
-        alert(e.response.data.message);
+        alert(e.response?.data.message);
       });
   }
 
@@ -79,7 +79,7 @@ function ChangePasswordModal() {
       })
       .catch((e) => {
         console.log('axios 통신실패');
-        alert(e.response.data.message);
+        alert(e.response?.data.message);
       });
   }
 
@@ -98,13 +98,13 @@ function ChangePasswordModal() {
         const statusCode = response.status;
         console.log("status code: " + statusCode);
         if (statusCode === 200) {
-          alert("비밀번호를 변경했습니다.");
+          alert(response.data.message);
           handleClose()
         }
       })
       .catch((e) => {
         console.log("axios 통신실패");
-        alert(e.response.data.message);
+        alert(e.response?.data.message);
       });
   }
 }

--- a/src/routes/auth/ChangePasswordModal.js
+++ b/src/routes/auth/ChangePasswordModal.js
@@ -5,8 +5,8 @@ import { useEffect, useState } from "react";
 import apiAxios from '../../utils/api-axios';
 
 function ChangePasswordModal() {
+  const [isSending, setIsSending] = useState(false);
   const [isVerified, setIsVerified] = useState(false);
-  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [verifyToken, setVerifyToken] = useState('');
@@ -16,15 +16,6 @@ function ChangePasswordModal() {
 
   const handleClose = () => dispatch(setShow(false));
 
-  useEffect(() => {
-    if (state.modal.modalName !== 'change-password' || !state.modal.show) {
-    } else if (!state.user.data?.email) {
-      alert('유저 정보에 이메일이 없어 발송에 실패했습니다.')
-    } else {
-      sendEmail(state.user.data.email);
-    }
-  }, [state.modal.modalName, state.modal.show])
-
   return (
     <Modal size="sm" show={state.modal.show} onHide={handleClose} centered>
       <Modal.Header closeButton>
@@ -33,7 +24,10 @@ function ChangePasswordModal() {
       <Modal.Body>
         <Form>
           <Form.Group className="mb-3">
-            {!email ? <Form.Text>인증메일 발송 중...</Form.Text> : ''}
+            <div className="d-grid gap-2 m-2">
+              <Button variant="outline-success" onClick={()=>{ sendEmail(); }}>인증번호 발송</Button>
+            </div>
+            {isSending ? <Form.Text>메일 보내는 중...</Form.Text> : ''}
             <InputGroup className="mb-2">
               <Form.Control id="p_confirm_email" name="confirm_email" type="text" placeholder='인증번호' autoFocus onChange={(e) => { setVerifyToken(e.target.value); }}/>
               <Button variant="outline-success" onClick={()=>{ confirmEmail(); }}>인증번호 확인</Button>
@@ -56,7 +50,7 @@ function ChangePasswordModal() {
 
   function confirmEmail() {
     apiAxios
-      .put(`/api/auth/emailverification`, { email: state.user.data?.email, verifyToken })
+      .put(`/api/auth/emailverification/password`, { verifyToken })
       .then((response) => {
         const statusCode = response.status;
         // console.log('status code: ' + statusCode);
@@ -71,20 +65,21 @@ function ChangePasswordModal() {
       });
   }
 
-  function sendEmail(email) {
+  function sendEmail() {
+    setIsSending(true);
     apiAxios
-      .post('/api/auth/emailverification', { email })
+      .post('/api/auth/emailverification/password', {})
       .then((response) => {
         const statusCode = response.status;
         console.log('status code: ' + statusCode);
         if (statusCode === 201) {
-          setEmail(state.user.data.email);
-          alert('인증번호를 이메일로 보냈습니다.');
+          setIsSending(false);
+          alert(`인증번호를 ${state.user.data?.email}로 보냈습니다.`);
         }
       })
       .catch((e) => {
         console.log('axios 통신실패');
-        console.log(e);
+        alert(e.response.data.message);
       });
   }
 
@@ -109,7 +104,7 @@ function ChangePasswordModal() {
       })
       .catch((e) => {
         console.log("axios 통신실패");
-        console.log(e);
+        alert(e.response.data.message);
       });
   }
 }

--- a/src/utils/api-axios.js
+++ b/src/utils/api-axios.js
@@ -32,11 +32,11 @@ apiAxios.interceptors.response.use(
     const refreshUrl = isAdminApi ? "/admin/auth/signin" : "/api/auth/refresh";
 
     if (
-      config.url === '/api/auth/emailverification' ||
+      config.url === '/api/auth/emailverification/signup' ||
       config.method === 'post' &&
+      config.url === '/api/auth/signup' ||
       config.url === '/api/auth/signin' ||
-      config.url.startsWith('/api/auth/oauth/signin') ||
-      config.url === '/admin/auth/signin'
+      config.url.startsWith('/api/auth/oauth/signin')
     ) {
       return Promise.reject(err);
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가   
- [x] 기능 수정   
- [ ] 기능 삭제   
- [x] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

### 변경 사항
- resolve #53
  - 인증 API에 요청하고 나면 백엔드에서 보내주는 message로 alert을 띄움.
    - 기존 alert이 안 뜨던 것들이 뜨게 됨. (회원가입 결과, 요청 유효성 검사 결과 등)
  - 인증 메일을 보내면 보내는 중이라는 Form.Text가 뜸
  - 인증번호를 인증하고 나면 이메일 인증 관련 버튼은 잠금.
  - 비밀번호 변경 이메일 인증메일 발송 버튼 만듬. ( 자동 => 수동)
  - 회원가입, 비밀번호 변경 버튼을 처음에는 disabled로 하고 다 채워지면 클릭 가능하게 만듬.

### 테스트 환경
- 백엔드 pr 올린 것 (브랜치: feature/auth-qa-fix) 와 함께 테스트해야함.