### PR TITLE
refactor: 관리자 중간발표 전 QA - 2차

### DIFF
--- a/src/routes/admin/AdminAccount.js
+++ b/src/routes/admin/AdminAccount.js
@@ -63,9 +63,8 @@ const AdminAccount = () => {
 
   function getList() {
     apiAxios
-      .get(getItemPath, { params: { search, p: page } })
+      .get(getItemPath, { params: { search: keyword.current, p: page } })
       .then(({ status, data }) => {
-        keyword.current = search;
         const { data: items, total, lastPage } = data;
         const mappingData = items.map((item) =>
           transform.map((fn) => fn(item))
@@ -85,6 +84,7 @@ const AdminAccount = () => {
 
   function goSearch() {
     setPage(1);
+    keyword.current = search;
     getList();
   }
 

--- a/src/routes/admin/AdminAccount.js
+++ b/src/routes/admin/AdminAccount.js
@@ -40,7 +40,7 @@ const AdminAccount = () => {
         onClick={() => {goSearch()}}
         onChange={(e) => setSearch(e.target.value)}
       />
-      <h2># {keyword.current === '' ? '전체' : keyword.current}</h2>
+      <h2># {keyword.current === '' ? '전체' : keyword.current} ({total})</h2>
       <AdminTable
         header={header}
         width={width}

--- a/src/routes/admin/AdminCollection.js
+++ b/src/routes/admin/AdminCollection.js
@@ -64,9 +64,8 @@ const AdminCollection = () => {
 
   function getList() {
     apiAxios
-      .get(getItemPath, { params: { search, p: page } })
+      .get(getItemPath, { params: { search: keyword.current, p: page } })
       .then(({ status, data }) => {
-        keyword.current = search;
         const { data: items, total, lastPage } = data;
         const mappingData = items.map((item) =>
           transform.map((fn) => fn(item))
@@ -89,6 +88,7 @@ const AdminCollection = () => {
 
   function goSearch() {
     setPage(1);
+    keyword.current = search;
     getList();
   }
 

--- a/src/routes/admin/AdminCollection.js
+++ b/src/routes/admin/AdminCollection.js
@@ -43,7 +43,7 @@ const AdminCollection = () => {
         onClick={() => {goSearch()}}
         onChange={(e) => setSearch(e.target.value)}
       />
-      <h2># {keyword.current === '' ? '전체' : keyword.current}</h2>
+      <h2># {keyword.current === '' ? '전체' : keyword.current} ({total})</h2>
       <AdminTable
         header={header}
         width={width}

--- a/src/routes/admin/AdminFAQ.js
+++ b/src/routes/admin/AdminFAQ.js
@@ -66,9 +66,8 @@ const AdminFAQ = () => {
 
   function getList() {
     apiAxios
-      .get(getItemPath, { params: { search, p: page } })
+      .get(getItemPath, { params: { search: keyword.current, p: page } })
       .then(({ status, data }) => {
-        keyword.current = search;
         const { data: items, total, lastPage } = data;
         const mappingData = items.map((item) =>
           transform.map((fn) => fn(item))
@@ -90,6 +89,7 @@ const AdminFAQ = () => {
 
   function goSearch() {
     setPage(1);
+    keyword.current = search;
     getList();
   }
 

--- a/src/routes/admin/AdminFAQ.js
+++ b/src/routes/admin/AdminFAQ.js
@@ -42,7 +42,7 @@ const AdminFAQ = () => {
         onClick={() => {goSearch()}}
         onChange={(e) => setSearch(e.target.value)}
       />
-      <h2># {keyword.current === '' ? '전체' : keyword.current}</h2>
+      <h2># {keyword.current === '' ? '전체' : keyword.current} ({total})</h2>
       <AdminTable
         header={header}
         width={width}

--- a/src/routes/admin/AdminMeetup.js
+++ b/src/routes/admin/AdminMeetup.js
@@ -35,7 +35,7 @@ const AdminMeetup = () => {
         onClick={() => {goSearch()}}
         onChange={(e) => setSearch(e.target.value)}
       />
-      <h2># {keyword.current === '' ? '전체' : keyword.current}</h2>
+      <h2># {keyword.current === '' ? '전체' : keyword.current} ({total})</h2>
       <AdminTable
         header={header}
         width={width}

--- a/src/routes/admin/AdminMeetup.js
+++ b/src/routes/admin/AdminMeetup.js
@@ -55,9 +55,8 @@ const AdminMeetup = () => {
 
   function getList() {
     apiAxios
-      .get(getItemPath, { params: { search, p: page } })
+      .get(getItemPath, { params: { search: keyword.current, p: page } })
       .then(({ status, data }) => {
-        keyword.current = search;
         const { data: items, total, lastPage } = data;
         const mappingData = items.map((item) =>
           transform.map((fn) => fn(item))
@@ -79,6 +78,7 @@ const AdminMeetup = () => {
 
   function goSearch() {
     setPage(1);
+    keyword.current = search;
     getList();
   }
 

--- a/src/routes/admin/AdminPhotospot.js
+++ b/src/routes/admin/AdminPhotospot.js
@@ -56,9 +56,8 @@ const AdminPhotospot = () => {
 
   function getList() {
     apiAxios
-      .get(getItemPath(collectionId), { params: { search, p: page } })
+      .get(getItemPath(collectionId), { params: { search: keyword.current, p: page } })
       .then(({ status, data: items }) => {
-        keyword.current = search;
         const mappingData = items.map((item) =>
           transform.map((fn) => fn(item))
         );
@@ -79,6 +78,7 @@ const AdminPhotospot = () => {
 
   function goSearch() {
     setPage(1);
+    keyword.current = search;
     getList();
   }
 

--- a/src/routes/admin/AdminPhotospot.js
+++ b/src/routes/admin/AdminPhotospot.js
@@ -42,7 +42,7 @@ const AdminPhotospot = () => {
         onClick={() => {goSearch()}}
         onChange={(e) => setSearch(e.target.value)}
       />
-      <h2># {keyword.current === '' ? '전체' : keyword.current}</h2>
+      <h2># {keyword.current === '' ? '전체' : keyword.current} ({total})</h2>
       <AdminTable
         header={header}
         width={width}

--- a/src/routes/admin/AdminUser.js
+++ b/src/routes/admin/AdminUser.js
@@ -51,9 +51,8 @@ const AdminUser = () => {
 
   function getList() {
     apiAxios
-      .get(getItemPath, { params: { search, p: page } })
+      .get(getItemPath, { params: { search: keyword.current, p: page } })
       .then(({ status, data }) => {
-        keyword.current = search;
         const { data: items, total, lastPage } = data;
         const mappingData = items.map((item) =>
           transform.map((fn) => fn(item))
@@ -75,6 +74,7 @@ const AdminUser = () => {
 
   function goSearch() {
     setPage(1);
+    keyword.current = search;
     getList();
   }
 

--- a/src/routes/admin/AdminUser.js
+++ b/src/routes/admin/AdminUser.js
@@ -31,7 +31,7 @@ const AdminUser = () => {
         onClick={() => {goSearch()}}
         onChange={(e) => setSearch(e.target.value)}
       />
-      <h2># {keyword.current === '' ? '전체' : keyword.current}</h2>
+      <h2># {keyword.current === '' ? '전체' : keyword.current} ({total})</h2>
       <AdminTable
         header={header}
         width={width}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [ ] 기능 추가   
- [x] 기능 수정   
- [ ] 기능 삭제   
- [ ] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

### 변경 사항
- resolve #68 
  - 관리자 페이지 이동시에 api 요청시 검색어로 검색창의 텍스트를 가져다 쓰는게 아닌 useRef로 만든 keyword의 current 값을 쓰도록 만듬.
  - keyword.current 값은 검색 시작시에만 변화를 주도록 변경
  - 관리자 페이지 검색 결과 총 갯수 표시