### PR TITLE
fix: meetups 생성 시 string으로 전달되던 schedule date 타입으로 전달되게 변경

### DIFF
--- a/src/routes/meetups/MeetupsCreateModal.js
+++ b/src/routes/meetups/MeetupsCreateModal.js
@@ -53,7 +53,7 @@ function MeetupsCreateModal(props) {
           title, 
           content, 
           place, 
-          schedule: `${scheduleDate} ${scheduleTime}`, 
+          schedule: new Date(`${scheduleDate} ${scheduleTime}`), 
           headcount
         },
         { withCredentials: true }
@@ -61,7 +61,7 @@ function MeetupsCreateModal(props) {
       .then(({ status, data }) => {
         if (status === 201) {
           handleClose();
-          window.location.reload();
+          props.resetMeetups();
         }
       })
       .catch(({ response }) => {

--- a/src/routes/meetups/MeetupsList.js
+++ b/src/routes/meetups/MeetupsList.js
@@ -58,7 +58,7 @@ const MeetupsList = () => {
     <>
       { loading && <Loading /> }
 
-      { state.modal.modalName === 'create' && <MeetupsCreateModal /> }
+      { state.modal.modalName === 'create' && <MeetupsCreateModal resetMeetups={resetMeetups} /> }
       { state.modal.modalName === 'detail' && 
         <MeetupsDetailModal 
           getMeetupDetail={getMeetupDetail} 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [ ] 기능 추가   
- [ ] 기능 수정   
- [ ] 기능 삭제   
- [x] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

### 변경 사항
- resolve #75 
  - meetup 생성 시 string으로 전달되던 schedule date 타입으로 전달되게 변경
  - meetup 생성 후 새로고침이 아닌 resetMeetups 함수를 통해 목록 재생성
